### PR TITLE
Fix/hex neighbour issues

### DIFF
--- a/src/visualise-graphs/api/FrontendStateManager.ts
+++ b/src/visualise-graphs/api/FrontendStateManager.ts
@@ -33,7 +33,7 @@ type FrontendStateManagerProps = {
     visitedNodes : Map<number | NOTSET_t, NodeType.START_NODE | NodeType.BOMB_NODE>,
     pathNodes : Set<number | NOTSET_t>,
     randomPathId : number | NOTSET_t,
-    executing : boolean
+    executing : boolean,
 }
 
 type FrontendStateManagerActions = {
@@ -112,7 +112,7 @@ const useFrontendStateManager =
         visitedNodes : new Map(),
         pathNodes : new Set(),
         randomPathId : NOTSET,
-        executing : false
+        executing : false,
     }))
 
 export default useFrontendStateManager;

--- a/src/visualise-graphs/api/MazeGenerator.ts
+++ b/src/visualise-graphs/api/MazeGenerator.ts
@@ -1,5 +1,5 @@
-import useFrontendStateManager from "../api/FrontendStateManager";
-import Pipe from "../api/Pipe";
+import useFrontendStateManager from "./FrontendStateManager";
+import Pipe from "./Pipe";
 
 /**
  * The basic maze generator class which builds the Sets required for
@@ -41,8 +41,34 @@ class MazeGenerator {
      */
     static genRidges(workableColumns: number, workableRows: number): Set<number> {
         if (workableColumns < 2 || workableRows < 2) return new Set();
-        // FIXME, The Hex Board Rendering update has broken this, because this was too tightly
-        // coupled with the board being linear.
+
+        let maze = new Set<number>()
+
+        const getDoors = (rows : number) :  [number, number] => {
+            const a = Math.floor(Math.random() * rows);
+            let b = Math.floor(Math.random() * (rows - 1));
+            if (b >= a) b += 1; // avoid collisions
+
+            return [a, b];
+        }
+
+        for (let col = 0 ; col<workableColumns ;col +=2){
+            // keep 2 random hex's/nodes in the column free to move around.
+            let [door1, door2] = getDoors(workableRows);
+            for (let row = 0 , doubledCoordinates = (col & 1) ===1 ? 1 : 0; row <workableRows ; ++row , doubledCoordinates +=2) {
+                const id = Pipe.pairToUUID(doubledCoordinates, col);
+                const startNodeId = useFrontendStateManager.getState().startNodeId;
+                const endNodeId = useFrontendStateManager.getState().endNodeId;
+                const bombNodeId = useFrontendStateManager.getState().bombNodeId;
+                if(door1 !== row &&
+                    door2 !== row &&
+                    id !== startNodeId &&
+                    id !== endNodeId &&
+                    id !== bombNodeId
+                ) maze.add(id);
+            }
+        }
+        return maze;
     }
 }
 

--- a/src/visualise-graphs/api/Pipe.ts
+++ b/src/visualise-graphs/api/Pipe.ts
@@ -32,4 +32,16 @@ export default class Pipe {
         }
         return map;
     }
+
+    /**
+     * Implementation of Szudzik's Elegant Pair function for two integers. It pipes 2 numbers through a tunnel
+     * and returns a collision free deterministic and unique consolidated integer every single time, and can serve
+     * the purpose of UUID in this case since it is easily reproducible. See {@link [this](http://szudzik.com/ElegantPairing.pdf)} for detailed paper
+     * and {@link [here](https://stackoverflow.com/questions/919612/mapping-two-integers-to-one-in-a-unique-and-deterministic-way)} for reference
+     * @param x
+     * @param y
+     */
+    public static pairToUUID(x : number , y : number) {
+        return Math.max(x, y) === x ? x * x + x + y : y * y + x;
+    }
 }

--- a/src/visualise-graphs/api/Syncer.ts
+++ b/src/visualise-graphs/api/Syncer.ts
@@ -26,14 +26,14 @@ export default class Syncer {
         BackendStateManager.graph().rmNode(id);
     }
 
-    // UNSTABLE.
+    // STABLE.
     static setGraph(
         rows: number,
         cols: number,
     ) {
         // New implementation,
         // 1st one is col, 2nd one is row.
-        // see https://www.redblobgames.com/grids/hexagons/#coordinates-doubled this visualisation + logic.
+        // see https://www.redblobgames.com/grids/hexagons/#coordinates-doubled for visualisation + logic.
         const offsets = [
             [0, 2], [0, -2], [1, -1], [1, + 1], [-1, -1], [-1, +1]
         ];
@@ -44,6 +44,7 @@ export default class Syncer {
             for (let row = 0, doubledCoordinates = startDoubledRow; row < rows; ++row, doubledCoordinates += 2) {
                 const fromId = Pipe.pairToUUID(doubledCoordinates, col);
                 for (const [dc, dr] of offsets) {
+                    // dc, dx (differential element?) and Delta Column and Delta Double Coordinates (c+dc)
                     const Dc = col + dc;
                     const Ddc = doubledCoordinates + dr;
                     // Bounds: col [0, cols), doubledRow [0, 2 * rows)
@@ -91,6 +92,5 @@ export default class Syncer {
     static async supervise(fn: ()=> Promise<void> | void) {
         if (!useFrontendStateManager.getState().executing) return;
         await fn();
-
     }
 }

--- a/src/visualise-graphs/api/Syncer.ts
+++ b/src/visualise-graphs/api/Syncer.ts
@@ -1,7 +1,8 @@
 import BackendStateManager from "@graph/api/BackendStateManager";
 import useFrontendStateManager, {NodeType} from "@graph/api/FrontendStateManager";
-import {NOTSET, NOTSET_t} from "@graph/ts/Types";
+import {NOTSET} from "@graph/ts/Types";
 import Graph from "@graph/ts/Graph";
+import Pipe from "./Pipe";
 
 export default class Syncer {
 
@@ -25,98 +26,31 @@ export default class Syncer {
         BackendStateManager.graph().rmNode(id);
     }
 
+    // UNSTABLE.
     static setGraph(
         rows: number,
         cols: number,
-        ids: number
     ) {
-        let columnID = 0;
-        let columnIDCenter = 0;
-        for (let i = 0; i < ids; i++) {
-            // first row conditions
-            if (i % rows === 0) {
-                columnID = i / rows;
-                if (columnID === 0) { // adj 2
-                    Syncer.setEdge(i, i + 1)
-                    Syncer.setEdge(i, i + rows)
-                } else if (columnID === cols - 1) {
-                    if (cols % 2 === 0) { // adj 3
-                        Syncer.setEdge(i, i + 1)
-                        Syncer.setEdge(i, i - rows)
-                        Syncer.setEdge(i, i - rows + 1)
-                    } else { // adj 2
-                        Syncer.setEdge(i, i + 1)
-                        Syncer.setEdge(i, i - rows)
+        // New implementation,
+        // 1st one is col, 2nd one is row.
+        // see https://www.redblobgames.com/grids/hexagons/#coordinates-doubled this visualisation + logic.
+        const offsets = [
+            [0, 2], [0, -2], [1, -1], [1, + 1], [-1, -1], [-1, +1]
+        ];
+
+        // Absolutely gorgeous.
+        for (let col = 0; col < cols; ++col) {
+            const startDoubledRow = (col & 1) === 1 ? 1 : 0;
+            for (let row = 0, doubledCoordinates = startDoubledRow; row < rows; ++row, doubledCoordinates += 2) {
+                const fromId = Pipe.pairToUUID(doubledCoordinates, col);
+                for (const [dc, dr] of offsets) {
+                    const Dc = col + dc;
+                    const Ddc = doubledCoordinates + dr;
+                    // Bounds: col [0, cols), doubledRow [0, 2 * rows)
+                    if (Dc >= 0 && Dc < cols && Ddc >= 0 && Ddc < 2 * rows) {
+                        const toId = Pipe.pairToUUID(Ddc, Dc);
+                        Syncer.setEdge(fromId, toId);
                     }
-                } else if (columnID % 2 === 0) { // 3 adj
-                    Syncer.setEdge(i, i + 1)
-                    Syncer.setEdge(i, i - rows)
-                    Syncer.setEdge(i, i + rows + 1)
-                } else { // 5 adj
-                    Syncer.setEdge(i, i + 1)
-                    Syncer.setEdge(i, i - rows)
-                    Syncer.setEdge(i, i + rows)
-                    Syncer.setEdge(i, i - rows + 1)
-                    Syncer.setEdge(i, i + rows + 1)
-                }
-            }
-            // last row conditions
-            else if ((i + 1) % rows === 0) {
-                columnID = (i + 1) / rows;
-                if (columnID === 1) { // adj 3
-                    Syncer.setEdge(i, i - 1)
-                    Syncer.setEdge(i, i + rows)
-                    Syncer.setEdge(i, i + rows - 1)
-                } else if (columnID === cols) {
-                    if (cols % 2 === 0) { // adj 2
-                        Syncer.setEdge(i, i - 1)
-                        Syncer.setEdge(i, i - rows)
-                    } else { // adj 3
-                        Syncer.setEdge(i, i - 1)
-                        Syncer.setEdge(i, i - rows)
-                        Syncer.setEdge(i, i - rows - 1)
-                    }
-                } else if (columnID % 2 === 0) { // 3 adj
-                    Syncer.setEdge(i, i - 1)
-                    Syncer.setEdge(i, i - rows)
-                    Syncer.setEdge(i, i + rows)
-                } else { // 5 adj
-                    Syncer.setEdge(i, i - 1)
-                    Syncer.setEdge(i, i - rows)
-                    Syncer.setEdge(i, i + rows)
-                    Syncer.setEdge(i, i - rows - 1)
-                    Syncer.setEdge(i, i + rows - 1)
-                }
-            }
-            // first column conditions
-            else if (i <= rows) { // adj 4
-                Syncer.setEdge(i, i - 1)
-                Syncer.setEdge(i, i + 1)
-                Syncer.setEdge(i, i + rows)
-                Syncer.setEdge(i, i + rows - 1)
-            }
-            //last column conditions
-            else if (i > (rows * (cols - 1))) { // adj 4
-                Syncer.setEdge(i, i - 1)
-                Syncer.setEdge(i, i + 1)
-                Syncer.setEdge(i, i - rows)
-                Syncer.setEdge(i, i - rows - 1)
-            } else { // adj 6
-                columnIDCenter = Math.floor(i / rows);
-                if (columnIDCenter % 2 !== 0) {
-                    Syncer.setEdge(i, i - 1)
-                    Syncer.setEdge(i, i + 1)
-                    Syncer.setEdge(i, i - rows)
-                    Syncer.setEdge(i, i + rows)
-                    Syncer.setEdge(i, i - rows + 1)
-                    Syncer.setEdge(i, i + rows + 1)
-                } else if (columnIDCenter % 2 === 0) {
-                    Syncer.setEdge(i, i - 1)
-                    Syncer.setEdge(i, i + 1)
-                    Syncer.setEdge(i, i - rows)
-                    Syncer.setEdge(i, i + rows)
-                    Syncer.setEdge(i, i - rows - 1)
-                    Syncer.setEdge(i, i + rows - 1)
                 }
             }
         }

--- a/src/visualise-graphs/components/file/handleBatFileClick.ts
+++ b/src/visualise-graphs/components/file/handleBatFileClick.ts
@@ -1,6 +1,6 @@
 import {match} from "ts-pattern";
 import {MazeType} from "@graph/ts/Types";
-import MazeGenerator from "@graph/ts/MazeGenerator";
+import MazeGenerator from "../../api/MazeGenerator";
 import useFrontendStateManager, {NodeType} from "@graph/api/FrontendStateManager";
 import Syncer from "@graph/api/Syncer";
 
@@ -23,16 +23,16 @@ const handleBatFileClick = (
     match(name as MazeType)
         .with(MazeType.GENERATE_BLOCKED_RIDGES, () => {
             const maze = MazeGenerator.genRidges(
-                Math.ceil(hexBoardDimensions.height / HEX_HEIGHT),
-                Math.ceil(hexBoardDimensions.width / HEX_WIDTH)
+                Math.ceil(hexBoardDimensions.width / HEX_WIDTH),
+                Math.ceil(hexBoardDimensions.height / HEX_HEIGHT)
             );
             const hexBoard = useFrontendStateManager.getState().hexBoard;
             maze.forEach(id => hexBoard[id] = NodeType.WALL_NODE)
         })
         .with(MazeType.GENERATE_WEIGHTED_RIDGES, () => {
             const maze = MazeGenerator.genRidges(
-                Math.ceil(hexBoardDimensions.height / HEX_HEIGHT),
-                Math.ceil(hexBoardDimensions.width / HEX_WIDTH)
+                Math.ceil(hexBoardDimensions.width / HEX_WIDTH),
+                Math.ceil(hexBoardDimensions.height / HEX_HEIGHT)
             );
             const hexBoard = useFrontendStateManager.getState().hexBoard;
             maze.forEach(id => hexBoard[id] = NodeType.WEIGHT_NODE) // Changed to use direct hexBoard update

--- a/src/visualise-graphs/components/hex-board/HexBoard.tsx
+++ b/src/visualise-graphs/components/hex-board/HexBoard.tsx
@@ -4,6 +4,7 @@ import Hex from "@graph/components/hex/Hex";
 import useFrontendStateManager, {NodeAction, NodeType} from "@graph/api/FrontendStateManager";
 import Syncer from "@graph/api/Syncer";
 import BackendStateManager from "@graph/api/BackendStateManager";
+import Pipe from "../../api/Pipe";
 
 /**
  * Renders the hexagonal board.
@@ -26,12 +27,26 @@ const HexBoard: React.FC = () => {
             const rows = Math.ceil(height / HEX_HEIGHT);
             const cols = Math.ceil(width / HEX_WIDTH);
             setHexBoard(rows, cols, HEX_WIDTH, HEX_HEIGHT);
-            Syncer.setGraph(rows, cols, rows * cols);
+            Syncer.setGraph(rows, cols);
             setLoading(false);
             let startPosition = Math.floor((rows * cols) * 0.25);
             let endPosition = Math.floor((rows * cols) * 0.75);
-            changeNode(NodeType.START_NODE, NodeAction.SET, startPosition);
-            changeNode(NodeType.END_NODE, NodeAction.SET, endPosition);
+
+            // need to be able to extract the id from flat list start & end positions.
+            const getDoubledCoordinatesPair = (index: number) => {
+                const col = Math.floor(index / rows);
+                const row = index % rows;
+                const doubledRow = (col & 1) === 1 ? 1 + row * 2 : row * 2;
+                return [doubledRow, col];
+            };
+            const [startRow, startCol] = getDoubledCoordinatesPair(startPosition);
+            const [endRow, endCol] = getDoubledCoordinatesPair(endPosition);
+
+            // get the Ids from the row & col.
+            const startId = Pipe.pairToUUID(startRow, startCol);
+            const endId = Pipe.pairToUUID(endRow, endCol);
+            changeNode(NodeType.START_NODE, NodeAction.SET, startId);
+            changeNode(NodeType.END_NODE, NodeAction.SET, endId);
             setHexBoardDimensions({width, height});
             BackendStateManager.initGraph().freeze();
         };

--- a/src/visualise-graphs/components/hex-board/populateHexBoard.ts
+++ b/src/visualise-graphs/components/hex-board/populateHexBoard.ts
@@ -1,21 +1,25 @@
-import {HexProps} from "@graph/components/hex/Hex";
-import Syncer from "@graph/api/Syncer";
-
+import {HexProps} from "../hex/Hex";
+import Syncer from "../../api/Syncer";
+import Pipe from "../../api/Pipe";
 const populateHexBoard = (rows: number, cols: number, HEX_WIDTH: number, HEX_HEIGHT: number) => {
     let content: HexProps[] = [];
-    let xVar = -14.5;
-    let yVar: number;
-    let idVar = 0;
-    for (let i = 0; i < cols; i++, xVar += HEX_WIDTH) {
-        // since the hexagons aren't in straight lines,
-        // we have to account for odd even.
-        yVar = (i & 1) === 1 ? -2.5 : -17;
-        for (let j = 0; j < rows; j++, idVar++) {
-            content.push({x: xVar, y: yVar, id: idVar});
-            yVar += HEX_HEIGHT;
-            Syncer.setNode(xVar, yVar, idVar)
+    let x = -14.5;
+
+    for (let col = 0; col < cols; col++, x += HEX_WIDTH) {
+        const isOddCol = (col & 1) === 1;
+        let y = isOddCol ? -2.5 : -17;
+
+        // see https://www.redblobgames.com/grids/hexagons/#coordinates-doubled for visualisation
+        let doubledCoordinates = isOddCol ? 1 : 0;
+
+        for (let row = 0; row < rows; row++, doubledCoordinates += 2, y += HEX_HEIGHT) {
+            const id = Pipe.pairToUUID(doubledCoordinates, col);
+            content.push({ x, y, id });
+            Syncer.setNode(x, y, id);
         }
     }
+
     return content;
-}
+};
+
 export default populateHexBoard;

--- a/src/visualise-graphs/components/hex/Hex.tsx
+++ b/src/visualise-graphs/components/hex/Hex.tsx
@@ -6,6 +6,7 @@ import {NOTSET} from "@graph/ts/Types";
 import cn from "@graph/css/cn";
 import {match} from "ts-pattern";
 import {FileType} from "../file/File";
+import BackendStateManager from "../../api/BackendStateManager";
 
 export type HexProps = {
     x: number;
@@ -33,6 +34,7 @@ const Hex: React.FC<HexProps> = ({x, y, id}) => {
 
     const activeIOFile = useFrontendStateManager(state => state.activeFiles.io);
     const changeNode = useFrontendStateManager(state => state.changeNode);
+
     /**
      * Change hex type based on the active IO file.
      */
@@ -65,7 +67,7 @@ const Hex: React.FC<HexProps> = ({x, y, id}) => {
 
     // Apply classes on the Hex Icon.
     let hexIconClasses = cn({
-        "visited-node": (visited === NodeType.START_NODE) && !pathNode,
+        "visited-node": (visited === NodeType.START_NODE) && !pathNode ,
         "icon": true,
         "visited-node-bomb": (visited === NodeType.BOMB_NODE) && !pathNode,
         "path-node": pathNode,

--- a/src/visualise-graphs/ts/MazeGenerator.ts
+++ b/src/visualise-graphs/ts/MazeGenerator.ts
@@ -1,4 +1,5 @@
 import useFrontendStateManager from "../api/FrontendStateManager";
+import Pipe from "../api/Pipe";
 
 /**
  * The basic maze generator class which builds the Sets required for
@@ -15,16 +16,17 @@ class MazeGenerator {
      * @returns a Set having the drawable IDs
      */
     static genRandomMaze(): Set<number> {
-        let path: Set<number> = new Set();
-        const size = useFrontendStateManager.getState().hexes.length;
-        for (let i = 0; i < size; i++) {
-            let randomID = Math.floor(Math.random() * size);
-            if (randomID !== useFrontendStateManager.getState().startNodeId &&
-                randomID !== useFrontendStateManager.getState().endNodeId &&
-                randomID !== useFrontendStateManager.getState().bombNodeId)
-                path.add(randomID);
+        let hexes = useFrontendStateManager.getState().hexes;
+        let maze: Set<number> = new Set();
+        for (let i = 0; i < hexes.length; i++) {
+            let randomId = Math.floor(Math.random() * hexes.length);
+            let hexId = hexes[randomId].id;
+            if (hexId !== useFrontendStateManager.getState().startNodeId &&
+                hexId !== useFrontendStateManager.getState().endNodeId &&
+                hexId !== useFrontendStateManager.getState().bombNodeId)
+                maze.add(hexes[randomId].id);
         }
-        return path;
+        return maze;
     }
 
     /**
@@ -37,36 +39,10 @@ class MazeGenerator {
      * Each Set contains a collection of IDs for the nodes which
      * can be blocked or changed to weight nodes on the website
      */
-    static genRidges(workableColumns: number,
-                     workableRows: number): Set<number> {
-        // first check for nullity case
-        if (workableColumns < 2 || workableRows < 2) {
-            return new Set();
-        }
-
-        // array to hold the "ridges"
-        let wallNodes: Set<number> = new Set();
-        // function which can be used to create 2 at random entry points for the path.
-        const generateRandomEntries = (colNo: number): {
-            p1: number,
-            p2: number
-        } => {
-            let p1: number = Math.floor(Math.random() * (workableRows) + (colNo * workableRows));
-            let p2: number = p1 + 1;
-            return {p1, p2}
-        }
-
-        for (let i: number = 0; i < workableColumns; i++) {
-            if ((i & 1) === 1) {
-                let entryPoints = generateRandomEntries(i);
-                for (let j: number = i * workableRows; j < workableRows * (i + 1); j++) {
-                    if (j !== entryPoints.p1 && j !== entryPoints.p2 && j !== useFrontendStateManager.getState().startNodeId && j !== useFrontendStateManager.getState().endNodeId && j !== useFrontendStateManager.getState().bombNodeId) {
-                        wallNodes.add(j);
-                    }
-                }
-            }
-        }
-        return wallNodes;
+    static genRidges(workableColumns: number, workableRows: number): Set<number> {
+        if (workableColumns < 2 || workableRows < 2) return new Set();
+        // FIXME, The Hex Board Rendering update has broken this, because this was too tightly
+        // coupled with the board being linear.
     }
 }
 


### PR DESCRIPTION
1. Changed logic for hexboard generation and linking with graph, especially the neighbor linking. 
2. Cleaned up the `setGraph()` function in `Syncer` to make it more streamlined using doubledCoordinates for offsets (maybe we will change it later the future to use [recommendation] cube coordinate) 
3. Maze Generator is now an API, and it has been changed to reflect Hex Board linking change, but there are some issues that need to be addr (minor only) 